### PR TITLE
issue-5: changed to create a working directory in new session

### DIFF
--- a/Rapid Reporter/CustomException.cs
+++ b/Rapid Reporter/CustomException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Rapid_Reporter
+{
+    public class InvalidDirecotoryException : Exception
+    {
+        public InvalidDirecotoryException() : base() { }
+        public InvalidDirecotoryException(string message) : base(message) { }
+        public InvalidDirecotoryException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/Rapid Reporter/Forms/SMWidget.xaml.cs
+++ b/Rapid Reporter/Forms/SMWidget.xaml.cs
@@ -325,26 +325,35 @@ namespace Rapid_Reporter.Forms
                     Logger.Record("\t[StateMove]: Session Stage moving -> Versions", "SMWidget", "info");
                     break;
                 case Session.SessionStartingStage.Notes:
-                    NoteContent.ToolTip = (100 < _currentSession.Charter.Length) ? _currentSession.Charter.Remove(100)+"..." : _currentSession.Charter;
-                    NoteType.Text = _currentSession.NoteTypes[_currentNoteType] + ":";
-                    prevType.Text = "? " + _currentSession.NoteTypes[_prevNoteType] + ":";
-                    nextType.Text = "? " + _currentSession.NoteTypes[_nextNoteType] + ":";
-                    NoteType.FontSize = 21;
-                    if (!skipStartSession) _currentSession.StartSession(); 
-                    ProgressGo(90); 
-                    t90.IsChecked = true;
-                    ScreenShot.IsEnabled = true; 
-                    RTFNoteBtn.IsEnabled = true;
-                    ResumeSession.IsEnabled = false;
-                    PauseSession.IsEnabled = true;
-                    // Change the icon of the image of the buttons, to NOT appear disabled.
-                    CloseButton.ToolTip = "Save and Quit";
-                    SaveAndQuitOption.Header = "Save and Quit";
-                    SaveAndNewOption.IsEnabled = true;
-                    ScreenShotIcon.Source = new BitmapImage(new Uri("iconshot.png", UriKind.Relative));
-                    RTFNoteBtnIcon.Source = new BitmapImage(new Uri("iconnotes.png", UriKind.Relative));
-                    TimerMenu.IsEnabled = true;
-                    Logger.Record("\t\t[StateMove]: Session Stage moving -> Notes", "SMWidget", "info");
+                    try
+                    {
+                        NoteContent.ToolTip = (100 < _currentSession.Charter.Length) ? _currentSession.Charter.Remove(100) + "..." : _currentSession.Charter;
+                        NoteType.Text = _currentSession.NoteTypes[_currentNoteType] + ":";
+                        prevType.Text = "? " + _currentSession.NoteTypes[_prevNoteType] + ":";
+                        nextType.Text = "? " + _currentSession.NoteTypes[_nextNoteType] + ":";
+                        NoteType.FontSize = 21;
+                        if (!skipStartSession) _currentSession.StartSession();
+                        ProgressGo(90);
+                        t90.IsChecked = true;
+                        ScreenShot.IsEnabled = true;
+                        RTFNoteBtn.IsEnabled = true;
+                        ResumeSession.IsEnabled = false;
+                        PauseSession.IsEnabled = true;
+                        // Change the icon of the image of the buttons, to NOT appear disabled.
+                        CloseButton.ToolTip = "Save and Quit";
+                        SaveAndQuitOption.Header = "Save and Quit";
+                        SaveAndNewOption.IsEnabled = true;
+                        ScreenShotIcon.Source = new BitmapImage(new Uri("iconshot.png", UriKind.Relative));
+                        RTFNoteBtnIcon.Source = new BitmapImage(new Uri("iconnotes.png", UriKind.Relative));
+                        TimerMenu.IsEnabled = true;
+                        Logger.Record("\t\t[StateMove]: Session Stage moving -> Notes", "SMWidget", "info");
+                    }
+                    catch (InvalidDirecotoryException e)
+                    {
+                        string msg = e.Message + " Application closed.";
+                        System.Windows.MessageBox.Show(msg, "Unable to Create a Folder", MessageBoxButton.OK, MessageBoxImage.Error);
+                        ExitApp(true);
+                    }
                     break;
                 default:
                     Logger.Record("\t[StateMove]: Session Stage moving -> NULL", "SMWidget", "error");

--- a/Rapid Reporter/Rapid Reporter.csproj
+++ b/Rapid Reporter/Rapid Reporter.csproj
@@ -111,6 +111,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </ApplicationDefinition>
+    <Compile Include="CustomException.cs" />
     <Compile Include="Updater.cs" />
     <Page Include="Forms\PlainTextNote.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/Rapid Reporter/Session.cs
+++ b/Rapid Reporter/Session.cs
@@ -65,14 +65,22 @@ namespace Rapid_Reporter
             UpdateNotes("Environment", Environment);
             UpdateNotes("Versions", Versions);
         }
-
-        private void CreateWorkingDir(String path)
+        
+        private void CreateWorkingDir(string path)
         {
             if (Directory.Exists(path))
             {
-                throw new InvalidDirecotoryException("A folder " + path + " already exits or could not be created.");
+                throw new InvalidDirecotoryException("A folder " + path + " already exits.");
             }
-            Directory.CreateDirectory(path);
+
+            try
+            {
+                Directory.CreateDirectory(path);
+            }
+            catch (Exception)
+            {
+                throw new InvalidDirecotoryException("A folder " + path + " could not be created.");
+            }
         }
 
         internal bool ResumeSession()

--- a/Rapid Reporter/Session.cs
+++ b/Rapid Reporter/Session.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -33,7 +33,7 @@ namespace Rapid_Reporter
         public string[] NoteTypes = { "Prerequisite", "Test", "Success", "Bug/Issue", "Note", "Follow Up", "Summary" };
 
         // Session files:
-        public string WorkingDir = Directory.GetCurrentDirectory() + @"\";  // File to write the session to
+        public string WorkingDir = Directory.GetCurrentDirectory() + @"\";  // Directory to write the session to
         private string _sessionFile;      // File to write the session to
         private string _sessionFileFull;  // workingDir + sessionFile
         public string SessionNote = "";         // Latest note only
@@ -53,8 +53,10 @@ namespace Rapid_Reporter
             Logger.Record("[StartSession]: Session configuration starting", "Session", "info");
 
             StartingTime = DateTime.Now; // The time the session started is used for many things, like knowing the session file name
+            WorkingDir = Directory.GetCurrentDirectory() + @"\" + StartingTime.ToString("yyyyMMdd_HHmmss") + @"\";
             _sessionFile = StartingTime.ToString("yyyyMMdd_HHmmss") + ".csv";
             _sessionFileFull = WorkingDir + _sessionFile; // All files should be written to a working directory -- be it current or not.
+            CreateWorkingDir(WorkingDir);
             SaveToSessionNotes(ColumnHeaders + "\n"); // Headers of the notes table
             //UpdateNotes("Reporter Tool Version", System.Windows.Forms.Application.ProductVersion);
             UpdateNotes("Session Reporter", Tester);
@@ -62,6 +64,15 @@ namespace Rapid_Reporter
             UpdateNotes("Session Charter", Charter);
             UpdateNotes("Environment", Environment);
             UpdateNotes("Versions", Versions);
+        }
+
+        private void CreateWorkingDir(String path)
+        {
+            if (Directory.Exists(path))
+            {
+                throw new InvalidDirecotoryException("A folder " + path + " already exits or could not be created.");
+            }
+            Directory.CreateDirectory(path);
         }
 
         internal bool ResumeSession()


### PR DESCRIPTION
Fixed issue https://github.com/makeit1/RapidReporterEx/issues/5: csv and image files should be saved in a folder

Added the following logic:
- create a working directory using session start time (yyyyMMdd_HHmmss)
- close the application if
   - the directory already exists
   - the directory cannot be created