### PR TITLE
issue-5: fixed directory to save plain text note

### DIFF
--- a/Rapid Reporter/Forms/SMWidget.xaml.cs
+++ b/Rapid Reporter/Forms/SMWidget.xaml.cs
@@ -333,6 +333,7 @@ namespace Rapid_Reporter.Forms
                         nextType.Text = "? " + _currentSession.NoteTypes[_nextNoteType] + ":";
                         NoteType.FontSize = 21;
                         if (!skipStartSession) _currentSession.StartSession();
+                        SetWorkingDir(_currentSession.WorkingDir);
                         ProgressGo(90);
                         t90.IsChecked = true;
                         ScreenShot.IsEnabled = true;


### PR DESCRIPTION
**Problem:** Plain text note was not created in a sub folder. Related to issue https://github.com/makeit1/RapidReporterEx/issues/5

**Fixed:** set working directory of plain text note window to the correct folder at start session.