### PR TITLE
issue-14: removed prefix from filename of plain text note and screenshot

### DIFF
--- a/Rapid Reporter/CommonUtil.cs
+++ b/Rapid Reporter/CommonUtil.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Rapid_Reporter
+{
+    internal static class CommonUtil
+    {
+        //extension must have a dot like ".txt"
+        internal static string GenerateFilename(string workingDir, string extension)
+        {
+            string filename;
+            do
+            {
+                filename = DateTime.Now.ToString("yyyyMMdd_HHmmss") + extension;
+            } while (System.IO.File.Exists(workingDir + filename));
+            return filename;
+        }
+    }
+}

--- a/Rapid Reporter/Forms/PlainTextNote.xaml.cs
+++ b/Rapid Reporter/Forms/PlainTextNote.xaml.cs
@@ -74,7 +74,7 @@ namespace Rapid_Reporter.Forms
             {
                 Logger.Record("\t[save_Click]: PlainText Note not empty, will save", "PlainTextNote", "info");
                 // Name the note, save to file
-                Sm.PlainTextNoteName = GenerateFilename();
+                Sm.PlainTextNoteName = CommonUtil.GenerateFilename(WorkingDir, ".txt");
                 bool exDrRetry;
                 do
                 {
@@ -112,16 +112,6 @@ namespace Rapid_Reporter.Forms
             // We not really 'close' the window. Close function deals with whether hiding or closing it.
             Close();
             Logger.Record("[save_Click]: PlainText Note saving mechanism done. Closed (hidden).", "PlainTextNote", "info");
-        }
-
-        private string GenerateFilename()
-        {
-            string filename;
-            do
-            {
-                filename = DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".txt";
-            } while (System.IO.File.Exists(WorkingDir + filename));
-            return filename;
         }
 
         // Always hide the window. Unless the app is being closed completely, then close too.

--- a/Rapid Reporter/Forms/PlainTextNote.xaml.cs
+++ b/Rapid Reporter/Forms/PlainTextNote.xaml.cs
@@ -74,7 +74,7 @@ namespace Rapid_Reporter.Forms
             {
                 Logger.Record("\t[save_Click]: PlainText Note not empty, will save", "PlainTextNote", "info");
                 // Name the note, save to file
-                Sm.PlainTextNoteName = generateFilename();
+                Sm.PlainTextNoteName = GenerateFilename();
                 bool exDrRetry;
                 do
                 {
@@ -114,7 +114,7 @@ namespace Rapid_Reporter.Forms
             Logger.Record("[save_Click]: PlainText Note saving mechanism done. Closed (hidden).", "PlainTextNote", "info");
         }
 
-        private string generateFilename()
+        private string GenerateFilename()
         {
             string filename;
             do

--- a/Rapid Reporter/Forms/PlainTextNote.xaml.cs
+++ b/Rapid Reporter/Forms/PlainTextNote.xaml.cs
@@ -31,7 +31,6 @@ namespace Rapid_Reporter.Forms
     public partial class PlainTextNote
     {
         public Boolean ForceClose = false;  // We keep the window open (although hidden) until the app is closed.
-        int _currentPlainTextNote = 1;             // The number of the notes helps putting them in order, and finding them between the files (timestamp alone may confuse people).
         public SmWidget Sm;                 // Our interface to toggle the visual of the button in the main window is by direct referencing.
         public string WorkingDir = Directory.GetCurrentDirectory() + @"\";      // The directory to save files
 
@@ -75,7 +74,7 @@ namespace Rapid_Reporter.Forms
             {
                 Logger.Record("\t[save_Click]: PlainText Note not empty, will save", "PlainTextNote", "info");
                 // Name the note, save to file
-                Sm.PlainTextNoteName = _currentPlainTextNote++.ToString(CultureInfo.InvariantCulture) + "_" + DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".txt";
+                Sm.PlainTextNoteName = DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".txt";
                 bool exDrRetry;
                 do
                 {

--- a/Rapid Reporter/Forms/PlainTextNote.xaml.cs
+++ b/Rapid Reporter/Forms/PlainTextNote.xaml.cs
@@ -74,7 +74,7 @@ namespace Rapid_Reporter.Forms
             {
                 Logger.Record("\t[save_Click]: PlainText Note not empty, will save", "PlainTextNote", "info");
                 // Name the note, save to file
-                Sm.PlainTextNoteName = DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".txt";
+                Sm.PlainTextNoteName = generateFilename();
                 bool exDrRetry;
                 do
                 {
@@ -112,6 +112,16 @@ namespace Rapid_Reporter.Forms
             // We not really 'close' the window. Close function deals with whether hiding or closing it.
             Close();
             Logger.Record("[save_Click]: PlainText Note saving mechanism done. Closed (hidden).", "PlainTextNote", "info");
+        }
+
+        private string generateFilename()
+        {
+            string filename;
+            do
+            {
+                filename = DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".txt";
+            } while (System.IO.File.Exists(WorkingDir + filename));
+            return filename;
         }
 
         // Always hide the window. Unless the app is being closed completely, then close too.

--- a/Rapid Reporter/Forms/SMWidget.xaml.cs
+++ b/Rapid Reporter/Forms/SMWidget.xaml.cs
@@ -28,7 +28,6 @@ namespace Rapid_Reporter.Forms
         // Session Notes variables
         private int _currentNoteType;		// The actual types are controlled by the Session class.
         private int _prevNoteType; private int _nextNoteType; // Used for the hints about the next note up or down.
-        private int _currentScreenshot = 1;		// The number of the screenshot (increases by 1). Helps putting them in order, and finding them between multiple the files.
         private string _screenshotName = "";		// Attached to a Session Note.
         public string PlainTextNoteName = "";			// Attached to a Session Note. Public because it is used *directly* by the RTFNote
 
@@ -543,7 +542,7 @@ namespace Rapid_Reporter.Forms
             bool exDrRetry;
 
             // Name the screenshot, save to disk
-            _screenshotName = _currentScreenshot++.ToString(CultureInfo.InvariantCulture) + "_" + DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".jpg";
+            _screenshotName = GenerateFilename();
             do
             {
                 exDrRetry = false;
@@ -562,6 +561,16 @@ namespace Rapid_Reporter.Forms
             // Put a visual effect to remember the tester there's an image on the attachment barrel
             var effect = new BevelBitmapEffect {BevelWidth = 2, EdgeProfile = EdgeProfile.BulgedUp};
             ScreenShot.BitmapEffect = effect;
+        }
+
+        private string GenerateFilename()
+        {
+            string filename;
+            do
+            {
+                filename = DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".jpg";
+            } while (System.IO.File.Exists(_currentSession.WorkingDir + filename));
+            return filename;
         }
 
         // The functions below set/unset the hotkey for screenshot
@@ -666,7 +675,6 @@ namespace Rapid_Reporter.Forms
             _currentNoteType = 0;		// The actual types are controlled by the Session class.
             _prevNoteType = 0;
             _nextNoteType = 0; // Used for the hints about the next note up or down.
-            _currentScreenshot = 1;		// The number of the screenshot (increases by 1). Helps putting them in order, and finding them between multiple the files.
             _screenshotName = "";		// Attached to a Session Note.
             PlainTextNoteName = "";			// Attached to a Session Note. Public because it is used *directly* by the RTFNote
             IsPlainTextDiagOpen = false;

--- a/Rapid Reporter/Forms/SMWidget.xaml.cs
+++ b/Rapid Reporter/Forms/SMWidget.xaml.cs
@@ -542,7 +542,7 @@ namespace Rapid_Reporter.Forms
             bool exDrRetry;
 
             // Name the screenshot, save to disk
-            _screenshotName = GenerateFilename();
+            _screenshotName = CommonUtil.GenerateFilename(_currentSession.WorkingDir, ".jpg");
             do
             {
                 exDrRetry = false;
@@ -561,16 +561,6 @@ namespace Rapid_Reporter.Forms
             // Put a visual effect to remember the tester there's an image on the attachment barrel
             var effect = new BevelBitmapEffect {BevelWidth = 2, EdgeProfile = EdgeProfile.BulgedUp};
             ScreenShot.BitmapEffect = effect;
-        }
-
-        private string GenerateFilename()
-        {
-            string filename;
-            do
-            {
-                filename = DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".jpg";
-            } while (System.IO.File.Exists(_currentSession.WorkingDir + filename));
-            return filename;
         }
 
         // The functions below set/unset the hotkey for screenshot

--- a/Rapid Reporter/Rapid Reporter.csproj
+++ b/Rapid Reporter/Rapid Reporter.csproj
@@ -89,6 +89,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommonUtil.cs" />
     <Compile Include="Forms\AboutForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Fixed issue https://github.com/makeit1/RapidReporterEx/issues/14: Prefix should be removed from filename of plain text note and screenshot

**Before the fix:**
Filename of plain text note has a prefix like 1_20190512_230608.txt.
Filename of screenshot has a prefix like 1_20190512_230608.jpg.

**After the fix:**
Filename of plain text note doesn't have a prefix like 20190512_230608.txt.
Filename of screenshot doesn't have a prefix like 20190512_230608.jpg.