### PR TITLE
issue-6: show confirmation dialog when close button is clicked

### DIFF
--- a/Rapid Reporter/Forms/SMWidget.xaml.cs
+++ b/Rapid Reporter/Forms/SMWidget.xaml.cs
@@ -106,9 +106,29 @@ namespace Rapid_Reporter.Forms
         //// Mainly, the session should be terminated (timing notes added to file too) and all windows closed.
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
-            Logger.Record("[CloseButton_Click]: Closing Form...", "SMWidget", "info");
-            Close();
+            if (_currentStage != Session.SessionStartingStage.Notes)
+            {
+                Close();
+            }
+            string[] msg = {
+                "Are you sure you want to create a html file and close the app?\n\n",
+                "Yes:\tCreate a html file and close the app.\n",
+                "No:\tClose the app without creating a html file.\n",
+                "Cancel:\tDon't close the app."
+            };
+            MessageBoxResult result = System.Windows.MessageBox.Show(String.Join("",msg), "User Confirmation", MessageBoxButton.YesNoCancel);
+            if (result == MessageBoxResult.Yes) {
+                Logger.Record("[CloseButton_Click]: Closing Form (Yes button was clicked)...", "SMWidget", "info");
+                Close();
+            }
+            else if (result == MessageBoxResult.No)
+            {
+                Logger.Record("[CloseButton_Click]: Closing Form (No button was clicked)...", "SMWidget", "info");
+                _currentSession.createHTML = false;
+                Close();
+            }
         }
+
         // Closing the form can't just close the window, it has to follow the finalization process
         private void SMWidgetForm_Closed(object sender, EventArgs e)
         {
@@ -663,6 +683,26 @@ namespace Rapid_Reporter.Forms
         }
 
         private void SaveAndNewOption_Click(object sender, RoutedEventArgs e)
+        {
+            string[] msg = {
+                "Are you sure you want to create a html file of the current session before starting new session?\n\n",
+                "Yes:\tCreate a html file and start new session.\n",
+                "No:\tStart new session without creating a html file.\n",
+                "Cancel:\tDon't close the current session."
+            };
+            MessageBoxResult result = System.Windows.MessageBox.Show(String.Join("", msg), "User Confirmation", MessageBoxButton.YesNoCancel);
+            if (result == MessageBoxResult.Yes)
+            {
+                CloseAndStartSession();
+            }
+            else if (result == MessageBoxResult.No)
+            {
+                _currentSession.createHTML = false;
+                CloseAndStartSession();
+            }
+        }
+
+        private void CloseAndStartSession()
         {
             // Session
             Logger.Record("[SaveAndNewOption_Click]: Closing Session...", "SMWidget", "info");

--- a/Rapid Reporter/Session.cs
+++ b/Rapid Reporter/Session.cs
@@ -44,6 +44,7 @@ namespace Rapid_Reporter
         public enum SessionStartingStage { Tester, ScenarioId, Charter, Environment, Versions, Notes }; // Tester == tester's name. Charter == session charter. Notes == all the notes of different note types.
         public SessionStartingStage CurrentStage = SessionStartingStage.Tester; // This is used only in the beginning, in order to receive the tester name and charter text
 
+        public bool createHTML = true;
         /** Sessions **/
         /**************/
 
@@ -112,7 +113,10 @@ namespace Rapid_Reporter
                             duration.Minutes.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0') + ":" +
                             duration.Seconds.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0'));
                 Logger.Record("[CloseSession]: Starting csv to html method...", "Session", "info");
-                Csv2Html(_sessionFileFull, false);
+                if (createHTML)
+                {
+                    Csv2Html(_sessionFileFull, false);
+                }
             }
 
             Logger.Record("[CloseSession]: ...Session closed", "Session", "info");


### PR DESCRIPTION
Fixed issue https://github.com/makeit1/RapidReporterEx/issues/6: Cancel doesn't work at creating a html file

Changed to show confirmation dialog when close button is clicked.

- a confirmation dialog is shown when "Quit" or "Save and Start New Session" button is clicked, 
    - if Yes is clicked, Save File dialog is shown.
        - if Save button is clicked, a file name becomes the entered file name.
        - if Cancel button is clicked, a file name becomes the default format {yyyyMMdd_HHmmss} - {scenarioId}.html
    - if No is clicked, the app or session is closed without creating a html file.
    - if Cancel is clicked, the app or session is not closed.

The design in issue https://github.com/makeit1/RapidReporterEx/issues/6 is "If Cancel is clicked, a html file is not created. The app is not closed." on Save File dialog.
However, it needs a big change in code. The dialog is called at closing the session and there is no way to cancel the closing process.
I decided not to fix it at this time.